### PR TITLE
Placed upper bound on cereal (0.4)

### DIFF
--- a/zip-conduit.cabal
+++ b/zip-conduit.cabal
@@ -19,7 +19,7 @@ Library
   Build-depends:
       base           >= 4.3 && < 5
     , bytestring     >= 0.9 && < 0.11
-    , cereal         == 0.3.*
+    , cereal         >= 0.3 && < 0.5
     , conduit        >= 0.5.5 && < 1.1
     , digest         == 0.0.*
     , directory      >= 1.1 && < 1.3


### PR DESCRIPTION
Hoping we could place an upper bound on cereal that is inclusive of the latest 0.4 releases.
Compiles fine for latest versions of cereal. 
