### PR TITLE
Removed upper bounds on some dependencies

### DIFF
--- a/zip-conduit.cabal
+++ b/zip-conduit.cabal
@@ -19,16 +19,16 @@ Library
   Build-depends:
       base           >= 4.3 && < 5
     , bytestring     >= 0.9 && < 0.11
-    , cereal         >= 0.3 && < 0.5
+    , cereal         >= 0.3
     , conduit        >= 1.1 && < 1.3
     , digest         == 0.0.*
     , directory      >= 1.1 && < 1.3
-    , filepath       == 1.3.*
+    , filepath       >= 1.3
     , mtl            >= 2.0 && < 2.3
     , old-time       >= 1.0 && < 1.2
-    , time           >= 1.4 && < 1.6
-    , transformers   >= 0.3 && < 0.5
-    , utf8-string    == 0.3.*
+    , time           >= 1.4
+    , transformers   >= 0.3
+    , utf8-string    >= 0.3
     , conduit-extra  == 1.1.*
     , resourcet      == 1.1.*
 
@@ -49,19 +49,19 @@ Test-suite tests
   Main-is:           Tests.hs
 
   Build-depends:
-      base           >= 4.3 && < 5
-    , bytestring     >= 0.9 && < 0.11
-    , conduit        >= 1.1 && < 1.3
-    , resourcet      == 1.1.*
-    , directory      >= 1.1 && < 1.3
-    , filepath       == 1.3.*
-    , HUnit          == 1.2.*
+      base
+    , bytestring
+    , conduit
+    , resourcet
+    , directory
+    , filepath
+    , HUnit          >= 1.2 && < 2.0
     , hpc            >= 0.5 && < 0.7
-    , mtl            >= 2.0 && < 2.3
+    , mtl
     , temporary      >= 1.1 && < 1.3
     , test-framework >= 0.6 && < 0.9
     , test-framework-hunit >= 0.2 && < 0.4
-    , time           >= 1.4 && < 1.6
+    , time
     , zip-conduit
 
   Ghc-options:       -Wall -fno-warn-unused-do-bind
@@ -74,15 +74,15 @@ Benchmark bench
   Main-is:           Bench.hs
 
   Build-depends:
-      base           >= 4.3 && < 5
-    , bytestring     >= 0.9 && < 0.11
-    , directory      >= 1.1 && < 1.3
-    , criterion      == 1.0.*
-    , filepath       == 1.3.*
-    , LibZip         >= 0.10 && < 0.12
+      base
+    , bytestring
+    , directory
+    , criterion      >= 1.0
+    , filepath
+    , LibZip         >= 0.10
     , random         >= 1.0 && < 1.2
     , temporary      >= 1.1 && < 1.3
-    , zip-archive    >= 0.1 && < 0.3
+    , zip-archive    >= 0.1
     , zip-conduit
 
   Ghc-options:       -Wall -fno-warn-unused-do-bind


### PR DESCRIPTION
The package can be built with latest stackage lts (7.8).
Also removed redundant versions for dependencies in benchmark and tests.(those are already set by library).

If you prefer, I can only bump upper bounds, not remove them.